### PR TITLE
Fix on issue #189

### DIFF
--- a/ebaysdk/connection.py
+++ b/ebaysdk/connection.py
@@ -149,7 +149,7 @@ class BaseConnection(object):
         requestData = self.build_request_data(verb, data, verb_attrs)
         if files:
             del(headers['Content-Type'])
-            if isinstance(requestData, basestring):  # pylint: disable-msg=E0602
+            if isinstance(requestData, str):  # pylint: disable-msg=E0602
                 requestData = {'XMLPayload': requestData}
 
         request = Request(self.method,

--- a/ebaysdk/utils.py
+++ b/ebaysdk/utils.py
@@ -97,7 +97,10 @@ def smart_encode_request_data(value):
         if sys.version_info[0] < 3:
             return value
 
-        return value.encode('utf-8')
+        if isinstance(value,str):
+           return value.encode('utf-8')
+        else:
+           return value 
 
     except UnicodeDecodeError:
         return value


### PR DESCRIPTION
The current _utils.py_ encodes all the requestData to utf-8 on Python 3.x 
It prompts "**AttributeError: 'dict' object has no attribute 'encode'**" issue for image upload case, which its value is a **{'XMLPayload': ....}** object.